### PR TITLE
feat: Implement plugin enhancements based on feedback (partial)

### DIFF
--- a/MJ12DevPlugin/MJ12DevPlugin.uplugin
+++ b/MJ12DevPlugin/MJ12DevPlugin.uplugin
@@ -1,0 +1,24 @@
+{
+  "FileVersion": 3,
+  "Version": 1,
+  "VersionName": "0.1",
+  "FriendlyName": "MJ12 Development Plugin",
+  "Description": "A plugin to house common development tools and utilities for MJ12.",
+  "Category": "MJ12",
+  "CreatedBy": "MJ12",
+  "CreatedByURL": "",
+  "DocsURL": "",
+  "MarketplaceURL": "",
+  "SupportURL": "",
+  "CanContainContent": true,
+  "IsBetaVersion": true,
+  "IsExperimentalVersion": false,
+  "Installed": false,
+  "Modules": [
+    {
+      "Name": "MJ12DevPluginModule",
+      "Type": "Runtime",
+      "LoadingPhase": "Default"
+    }
+  ]
+}

--- a/MJ12DevPlugin/Source/MJ12DevPluginModule/MJ12DevPluginModule.Build.cs
+++ b/MJ12DevPlugin/Source/MJ12DevPluginModule/MJ12DevPluginModule.Build.cs
@@ -1,0 +1,50 @@
+using UnrealBuildTool;
+
+public class MJ12DevPluginModule : ModuleRules
+{
+    public MJ12DevPluginModule(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+
+        PublicIncludePaths.AddRange(
+            new string[] {
+                // ... add public include paths required here ...
+            }
+            );
+
+
+        PrivateIncludePaths.AddRange(
+            new string[] {
+                // ... add other private include paths required here ...
+            }
+            );
+
+
+        PublicDependencyModuleNames.AddRange(
+            new string[]
+            {
+                "Core",
+                "CoreUObject",
+                "Engine"
+                // ... add other public dependencies here ...
+            }
+            );
+
+
+        PrivateDependencyModuleNames.AddRange(
+            new string[]
+            {
+                "GameplayTags"
+                // ... add private dependencies here ...
+            }
+            );
+
+
+        DynamicallyLoadedModuleNames.AddRange(
+            new string[]
+            {
+                // ... add any modules that your module loads dynamically here ...
+            }
+            );
+    }
+}

--- a/MJ12DevPlugin/Source/MJ12DevPluginModule/Private/MJ12DevPluginComponents.cpp
+++ b/MJ12DevPlugin/Source/MJ12DevPluginModule/Private/MJ12DevPluginComponents.cpp
@@ -1,0 +1,748 @@
+// MJ12DevPluginComponents.cpp
+
+#include "ItemData.h"
+#include "InventoryComponent.h"
+#include "EquipmentComponent.h"
+#include "ItemTableRow.h"
+
+#include "Engine/DataTable.h"
+#include "Engine/StreamableManager.h"
+#include "Engine/AssetManager.h"
+#include "Net/UnrealNetwork.h"
+#include "GameFramework/Actor.h" 
+#include "GameplayTagsManager.h"
+
+// --- UItemData Implementation ---
+bool UItemData::AreAssetsLoaded() const
+{
+    bool bAreLoaded = true;
+    if (StaticMesh.ToSoftObjectPath().IsValid() && !StaticMesh.Get()) bAreLoaded = false;
+    if (SkeletalMesh.ToSoftObjectPath().IsValid() && !SkeletalMesh.Get()) bAreLoaded = false;
+    if (Icon.ToSoftObjectPath().IsValid() && !Icon.Get()) bAreLoaded = false;
+    return bAreLoaded;
+}
+
+
+// --- UInventoryComponent Implementation ---
+
+UInventoryComponent::UInventoryComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false; 
+    SetIsReplicatedByDefault(true);
+}
+
+void UInventoryComponent::BeginPlay()
+{
+    Super::BeginPlay();
+
+    if (GetOwnerRole() == ENetRole::ROLE_Authority || GetNetMode() == NM_Standalone)
+    {
+        for (int32 i = 0; i < Inventory.Num(); ++i)
+        {
+            if (Inventory[i].ItemID != NAME_None && !Inventory[i].ItemDataInstance)
+            {
+                RequestLoadItemData(Inventory[i].ItemID, [this, i](UItemData* LoadedData) {
+                    HandleItemDataLoaded(Inventory[i].ItemID, LoadedData, i);
+                });
+            }
+        }
+    }
+}
+
+void UInventoryComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    FStreamableManager& Streamable = UAssetManager::GetStreamableManager();
+    for (auto const& [ItemID, Handle] : ActiveLoadHandles)
+    {
+        if (Handle.IsValid())
+        {
+            Handle->CancelHandle();
+        }
+    }
+    ActiveLoadHandles.Empty();
+    Super::EndPlay(EndPlayReason);
+}
+
+void UInventoryComponent::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+    Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+    DOREPLIFETIME(UInventoryComponent, Inventory);
+}
+
+void UInventoryComponent::OnRep_Inventory()
+{
+    PendingOnRepLoads = 0;
+    bool bAnyLoadRequested = false;
+
+    for (int32 i = 0; i < Inventory.Num(); ++i)
+    {
+        if (Inventory[i].ItemID != NAME_None && !Inventory[i].ItemDataInstance)
+        {
+            PendingOnRepLoads++;
+            bAnyLoadRequested = true;
+            RequestLoadItemData(Inventory[i].ItemID, [this, ItemID = Inventory[i].ItemID, i](UItemData* LoadedData) {
+                HandleItemDataLoaded(ItemID, LoadedData, i, true /*bFromOnRep*/);
+            });
+        }
+        else if(Inventory[i].ItemID != NAME_None && Inventory[i].ItemDataInstance)
+        {
+             OnInventorySlotUpdated.Broadcast(Inventory[i]);
+        }
+    }
+
+    if (!bAnyLoadRequested) 
+    {
+        OnInventoryReloaded.Broadcast();
+    }
+}
+
+void UInventoryComponent::HandleItemDataLoaded(FName ItemID, UItemData* LoadedData, int32 SlotIndex, bool bFromOnRep)
+{
+    if (!LoadedData)
+    {
+        UE_LOG(LogMJ12DevPlugin, Warning, TEXT("HandleItemDataLoaded: LoadedData is null for ItemID %s"), *ItemID.ToString());
+        if (bFromOnRep)
+        {
+            PendingOnRepLoads--;
+            if (PendingOnRepLoads <= 0)
+            {
+                OnInventoryReloaded.Broadcast();
+            }
+        }
+        return;
+    }
+
+    if (SlotIndex != -1 && Inventory.IsValidIndex(SlotIndex) && Inventory[SlotIndex].ItemID == ItemID)
+    {
+        Inventory[SlotIndex].ItemDataInstance = LoadedData;
+        OnInventorySlotUpdated.Broadcast(Inventory[SlotIndex]);
+    }
+    else 
+    {
+        for(FInventorySlot& Slot : Inventory)
+        {
+            if(Slot.ItemID == ItemID && !Slot.ItemDataInstance) 
+            {
+                Slot.ItemDataInstance = LoadedData;
+                OnInventorySlotUpdated.Broadcast(Slot);
+                break; 
+            }
+        }
+    }
+
+    if (bFromOnRep)
+    {
+        PendingOnRepLoads--;
+        if (PendingOnRepLoads <= 0)
+        {
+            OnInventoryReloaded.Broadcast();
+        }
+    }
+}
+
+
+bool UInventoryComponent::AddItem(FName ItemID, int32 Quantity)
+{
+    if (ItemID == NAME_None || Quantity <= 0)
+    {
+        UE_LOG(LogMJ12DevPlugin, Warning, TEXT("AddItem: Invalid ItemID or Quantity. ItemID: %s, Quantity: %d"), *ItemID.ToString(), Quantity);
+        return false;
+    }
+
+    if (!ItemDataTable)
+    {
+        UE_LOG(LogMJ12DevPlugin, Error, TEXT("AddItem: ItemDataTable is not set!"));
+        return false;
+    }
+
+    FItemTableRow* Row = ItemDataTable->FindRow<FItemTableRow>(ItemID, TEXT("AddItem"));
+    if (!Row)
+    {
+        UE_LOG(LogMJ12DevPlugin, Warning, TEXT("AddItem: ItemID %s not found in ItemDataTable."), *ItemID.ToString());
+        return false;
+    }
+
+    if (GetOwnerRole() == ROLE_Authority || GetNetMode() == NM_Standalone)
+    {
+        RequestLoadItemData(ItemID, [this, ItemID, Quantity, RowData = *Row](UItemData* LoadedItemData) {
+            if (!LoadedItemData) return; 
+
+            int32 RemainingQuantity = Quantity;
+            int32 SlotIndexToUpdate = -1;
+
+            if (LoadedItemData->MaxStackSize > 1)
+            {
+                for (int32 i = 0; i < Inventory.Num(); ++i)
+                {
+                    if (Inventory[i].ItemID == ItemID && Inventory[i].Quantity < LoadedItemData->MaxStackSize)
+                    {
+                        int32 CanAdd = FMath::Min(RemainingQuantity, LoadedItemData->MaxStackSize - Inventory[i].Quantity);
+                        Inventory[i].Quantity += CanAdd;
+                        RemainingQuantity -= CanAdd;
+                        Inventory[i].ItemDataInstance = LoadedItemData; 
+                        SlotIndexToUpdate = i;
+                        if (RemainingQuantity <= 0) break;
+                    }
+                }
+            }
+
+            while (RemainingQuantity > 0)
+            {
+                int32 AddAmount = FMath::Min(RemainingQuantity, LoadedItemData->MaxStackSize);
+                FInventorySlot NewSlot(ItemID, AddAmount);
+                NewSlot.ItemDataInstance = LoadedItemData;
+                Inventory.Add(NewSlot); 
+                SlotIndexToUpdate = Inventory.Num() - 1; 
+                RemainingQuantity -= AddAmount;
+            }
+
+            if(Inventory.IsValidIndex(SlotIndexToUpdate))
+            {
+                 OnInventorySlotUpdated.Broadcast(Inventory[SlotIndexToUpdate]);
+            }
+            else if (Inventory.Num() > 0) 
+            {
+                OnInventorySlotUpdated.Broadcast(Inventory.Last());
+            }
+        });
+    }
+    else
+    {
+         UE_LOG(LogMJ12DevPlugin, Warning, TEXT("AddItem called on client for %s. This should typically be a server RPC."), *GetOwner()->GetName());
+         return false; 
+    }
+
+    return true; 
+}
+
+bool UInventoryComponent::RemoveItem(FName ItemID, int32 Quantity)
+{
+    if (ItemID == NAME_None || Quantity <= 0) return false;
+    if (GetOwnerRole() < ROLE_Authority) 
+    {
+        UE_LOG(LogMJ12DevPlugin, Warning, TEXT("RemoveItem called on client. Denied."));
+        return false;
+    }
+
+    int32 QuantityToRemove = Quantity;
+    bool bItemRemoved = false;
+
+    for (int32 i = Inventory.Num() - 1; i >= 0; --i) 
+    {
+        if (Inventory[i].ItemID == ItemID)
+        {
+            int32 CanRemove = FMath::Min(QuantityToRemove, Inventory[i].Quantity);
+            Inventory[i].Quantity -= CanRemove;
+            QuantityToRemove -= CanRemove;
+
+            FInventorySlot UpdatedSlot = Inventory[i]; 
+
+            if (Inventory[i].Quantity <= 0)
+            {
+                Inventory.RemoveAt(i);
+                UpdatedSlot.Quantity = 0; 
+            }
+            bItemRemoved = true;
+            OnInventorySlotUpdated.Broadcast(UpdatedSlot); 
+
+            if (QuantityToRemove <= 0) break;
+        }
+    }
+
+    return bItemRemoved && QuantityToRemove == 0; 
+}
+
+bool UInventoryComponent::RemoveItemAt(int32 SlotIndex, int32 Quantity)
+{
+    if (!Inventory.IsValidIndex(SlotIndex) || Quantity <= 0) return false;
+    if (GetOwnerRole() < ROLE_Authority) 
+    {
+         UE_LOG(LogMJ12DevPlugin, Warning, TEXT("RemoveItemAt called on client. Denied."));
+        return false;
+    }
+
+    FInventorySlot& Slot = Inventory[SlotIndex];
+    int32 QuantityToRemove = FMath::Min(Quantity, Slot.Quantity);
+    Slot.Quantity -= QuantityToRemove;
+
+    FInventorySlot UpdatedSlot = Slot; 
+
+    if (Slot.Quantity <= 0)
+    {
+        Inventory.RemoveAt(SlotIndex);
+        UpdatedSlot.Quantity = 0; 
+    }
+
+    OnInventorySlotUpdated.Broadcast(UpdatedSlot);
+
+    return true;
+}
+
+
+int32 UInventoryComponent::GetItemQuantity(FName ItemID) const
+{
+    int32 TotalQuantity = 0;
+    for (const FInventorySlot& Slot : Inventory)
+    {
+        if (Slot.ItemID == ItemID)
+        {
+            TotalQuantity += Slot.Quantity;
+        }
+    }
+    return TotalQuantity;
+}
+
+bool UInventoryComponent::FindItemSlot(FName ItemID, FInventorySlot& OutSlot, int32& OutSlotIndex) const
+{
+    for (int32 i = 0; i < Inventory.Num(); ++i)
+    {
+        if (Inventory[i].ItemID == ItemID)
+        {
+            OutSlot = Inventory[i];
+            OutSlotIndex = i;
+            return true;
+        }
+    }
+    OutSlotIndex = -1;
+    return false;
+}
+
+UItemData* UInventoryComponent::GetItemData(FName ItemID) const
+{
+    for (const FInventorySlot& Slot : Inventory)
+    {
+        if (Slot.ItemID == ItemID && Slot.ItemDataInstance)
+        {
+            return Slot.ItemDataInstance;
+        }
+    }
+    return nullptr;
+}
+
+
+void UInventoryComponent::RequestLoadItemData(FName ItemID, TFunction<void(UItemData*)> Callback)
+{
+    if (ItemID == NAME_None)
+    {
+        Callback(nullptr);
+        return;
+    }
+
+    for (const FInventorySlot& Slot : Inventory)
+    {
+        if (Slot.ItemID == ItemID && Slot.ItemDataInstance && Slot.ItemDataInstance->AreAssetsLoaded())
+        {
+            Callback(Slot.ItemDataInstance);
+            return;
+        }
+    }
+
+    if (ActiveLoadHandles.Contains(ItemID) && ActiveLoadHandles[ItemID].IsValid())
+    {
+        for (const FInventorySlot& Slot : Inventory) {
+            if (Slot.ItemID == ItemID && Slot.ItemDataInstance) {
+                Callback(Slot.ItemDataInstance); 
+                return;
+            }
+        }
+        Callback(nullptr); 
+        return;
+    }
+
+    if (!ItemDataTable)
+    {
+        UE_LOG(LogMJ12DevPlugin, Error, TEXT("RequestLoadItemData: ItemDataTable is not set!"));
+        Callback(nullptr);
+        return;
+    }
+
+    FItemTableRow* Row = ItemDataTable->FindRow<FItemTableRow>(ItemID, TEXT("LoadItemData"));
+    if (!Row)
+    {
+        UE_LOG(LogMJ12DevPlugin, Warning, TEXT("RequestLoadItemData: ItemID %s not found in ItemDataTable."), *ItemID.ToString());
+        Callback(nullptr);
+        return;
+    }
+
+    UItemData* NewItemData = NewObject<UItemData>(this); 
+    NewItemData->ItemID = Row->ItemID;
+    NewItemData->DisplayName = Row->DisplayName;
+    NewItemData->StaticMesh = Row->StaticMesh;
+    NewItemData->SkeletalMesh = Row->SkeletalMesh;
+    NewItemData->Icon = Row->Icon;
+    NewItemData->MaxStackSize = Row->MaxStackSize;
+    NewItemData->Weight = Row->Weight;
+    NewItemData->ItemTags = Row->ItemTags;
+    NewItemData->EquipTargetSlotTag = Row->EquipTargetSlotTag;
+
+    TArray<FSoftObjectPath> AssetsToLoad;
+    if (Row->StaticMesh.ToSoftObjectPath().IsValid() && !Row->StaticMesh.Get()) AssetsToLoad.Add(Row->StaticMesh.ToSoftObjectPath());
+    if (Row->SkeletalMesh.ToSoftObjectPath().IsValid() && !Row->SkeletalMesh.Get()) AssetsToLoad.Add(Row->SkeletalMesh.ToSoftObjectPath());
+    if (Row->Icon.ToSoftObjectPath().IsValid() && !Row->Icon.Get()) AssetsToLoad.Add(Row->Icon.ToSoftObjectPath());
+
+    if (AssetsToLoad.Num() > 0)
+    {
+        FStreamableManager& Streamable = UAssetManager::GetStreamableManager();
+        TSharedPtr<FStreamableHandle> Handle = Streamable.RequestAsyncLoad(AssetsToLoad, FStreamableDelegate::CreateUObject(this, &UInventoryComponent::OnAssetsLoaded, NewItemData, Callback, ItemID));
+        ActiveLoadHandles.Add(ItemID, Handle);
+    }
+    else 
+    {
+        Callback(NewItemData);
+    }
+}
+
+void UInventoryComponent::OnAssetsLoaded(UItemData* LoadedItemData, TFunction<void(UItemData*)> OriginalCallback, FName ItemID)
+{
+    ActiveLoadHandles.Remove(ItemID);
+
+    if (IsValid(LoadedItemData))
+    {
+        OriginalCallback(LoadedItemData);
+    }
+    else
+    {
+        UE_LOG(LogMJ12DevPlugin, Warning, TEXT("OnAssetsLoaded: LoadedItemData for %s became invalid before callback execution."), *ItemID.ToString());
+        OriginalCallback(nullptr);
+    }
+}
+
+// Server RPCs for UInventoryComponent
+
+bool UInventoryComponent::ServerAddItem_Validate(FName ItemID, int32 Quantity)
+{
+    // Add basic validation if needed (e.g., Quantity > 0)
+    // For now, just return true. More complex validation can be added.
+    if (ItemID == NAME_None || Quantity <= 0)
+    {
+        return false;
+    }
+    return true;
+}
+
+void UInventoryComponent::ServerAddItem_Implementation(FName ItemID, int32 Quantity)
+{
+    // The AddItem function already contains an authority check.
+    // If it didn't, you would add one here: if (GetOwnerRole() == ROLE_Authority)
+    AddItem(ItemID, Quantity);
+}
+
+bool UInventoryComponent::ServerRemoveItem_Validate(FName ItemID, int32 Quantity)
+{
+    if (ItemID == NAME_None || Quantity <= 0)
+    {
+        return false;
+    }
+    return true;
+}
+
+void UInventoryComponent::ServerRemoveItem_Implementation(FName ItemID, int32 Quantity)
+{
+    RemoveItem(ItemID, Quantity);
+}
+
+bool UInventoryComponent::ServerRemoveItemAt_Validate(int32 SlotIndex, int32 Quantity)
+{
+    if (SlotIndex < 0 || Quantity <= 0) // Basic check, inventory bounds checked in RemoveItemAt
+    {
+        return false;
+    }
+    return true;
+}
+
+void UInventoryComponent::ServerRemoveItemAt_Implementation(int32 SlotIndex, int32 Quantity)
+{
+    RemoveItemAt(SlotIndex, Quantity);
+}
+
+
+// --- UEquipmentComponent Implementation ---
+
+UEquipmentComponent::UEquipmentComponent()
+{
+    SetIsReplicatedByDefault(true);
+}
+
+void UEquipmentComponent::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+    Super::GetLifetimeReplicatedProps(OutLifetimeProps); 
+    DOREPLIFETIME(UEquipmentComponent, EquippedItems);
+}
+
+void UEquipmentComponent::OnRep_EquippedItems()
+{
+    for (auto const& Pair : EquippedItems)
+    {
+        const FGameplayTag& SlotTag = Pair.Key;
+        const FInventorySlot& Slot = Pair.Value;
+
+        if (Slot.ItemID != NAME_None && !Slot.ItemDataInstance)
+        {
+            RequestLoadItemData(Slot.ItemID, [this, SlotTag, ItemID = Slot.ItemID](UItemData* LoadedData) {
+                 if (EquippedItems.Contains(SlotTag) && EquippedItems[SlotTag].ItemID == ItemID)
+                 {
+                    EquippedItems[SlotTag].ItemDataInstance = LoadedData;
+                    OnEquipmentSlotChanged.Broadcast(SlotTag, &EquippedItems[SlotTag]);
+                 }
+            });
+        }
+        else if (Slot.ItemID != NAME_None && Slot.ItemDataInstance)
+        {
+            OnEquipmentSlotChanged.Broadcast(SlotTag, &Slot);
+        }
+        else if (Slot.ItemID == NAME_None) 
+        {
+             OnEquipmentSlotChanged.Broadcast(SlotTag, nullptr);
+        }
+    }
+}
+
+
+bool UEquipmentComponent::CanEquipItem(const UItemData* ItemDataToEquip, FGameplayTag TargetEquipSlotTag) const
+{
+    if (!ItemDataToEquip)
+    {
+        UE_LOG(LogMJ12DevPlugin, Warning, TEXT("CanEquipItem: ItemDataToEquip is null."));
+        return false;
+    }
+
+    if (!ItemDataToEquip->EquipTargetSlotTag.MatchesTag(TargetEquipSlotTag))
+    {
+        UE_LOG(LogMJ12DevPlugin, Log, TEXT("CanEquipItem: Item %s (targets %s) cannot be equipped in slot %s."),
+            *ItemDataToEquip->ItemID.ToString(),
+            *ItemDataToEquip->EquipTargetSlotTag.ToString(),
+            *TargetEquipSlotTag.ToString());
+        return false;
+    }
+
+    return true;
+}
+
+bool UEquipmentComponent::EquipItemFromInventory(FGameplayTag TargetEquipSlotTag, FName ItemIDFromInventory)
+{
+    if (GetOwnerRole() < ROLE_Authority)
+    {
+        UE_LOG(LogMJ12DevPlugin, Warning, TEXT("EquipItemFromInventory called on Client for %s. Denied."), *GetOwner()->GetName());
+        return false;
+    }
+
+    if (TargetEquipSlotTag == FGameplayTag::EmptyTag || ItemIDFromInventory == NAME_None)
+    {
+        UE_LOG(LogMJ12DevPlugin, Warning, TEXT("EquipItemFromInventory: Invalid TargetEquipSlotTag or ItemIDFromInventory."));
+        return false;
+    }
+
+    FInventorySlot ItemToEquipSlotRecord; // Use a record to pass data to lambda if needed, or capture necessary parts
+    int32 ItemSlotIndex = -1;
+    if (!FindItemSlot(ItemIDFromInventory, ItemToEquipSlotRecord, ItemSlotIndex))
+    {
+        UE_LOG(LogMJ12DevPlugin, Warning, TEXT("EquipItemFromInventory: Item %s not found in inventory."), *ItemIDFromInventory.ToString());
+        return false;
+    }
+
+    // Define the core equip logic as a callable lambda or nested function
+    // This makes it reusable after ItemData is confirmed loaded.
+    auto PerformEquipLogic = [this, TargetEquipSlotTag, ItemIDFromInventory, ItemSlotIndex](UItemData* LoadedItemData)
+    {
+        if (!LoadedItemData)
+        {
+            UE_LOG(LogMJ12DevPlugin, Warning, TEXT("EquipItemFromInventory: LoadedItemData is null for %s after async load. Cannot equip."), *ItemIDFromInventory.ToString());
+            // Optionally, broadcast a failure event here if needed
+            return; // Explicitly not returning bool from lambda to match TFunction<void(UItemData*)> if RequestLoadItemData expects that for some paths.
+                    // The outer function's bool return indicates initiation.
+        }
+
+        // Ensure the original slot data is up-to-date with the loaded ItemDataInstance
+        // This is crucial because ItemToEquipSlotRecord might be a copy.
+        // We need to work with the actual inventory item or ensure ItemToEquipSlotRecord is what we need.
+        // For simplicity, let's re-fetch or assume the ItemDataInstance in the main inventory array (if applicable)
+        // would be set by RequestLoadItemData's internal workings if it caches.
+        // Given our RequestLoadItemData implementation, it creates a NEW UItemData.
+        // The slot in the main inventory (if this item is from there) would need its ItemDataInstance updated.
+        // The lambda in the original RequestLoadItemData call in AddItem handles associating this.
+        // For EquipItemFromInventory, the ItemToEquipSlotRecord.ItemDataInstance will be null if it wasn't loaded before.
+        // We now have `LoadedItemData`.
+
+        FInventorySlot ActualItemToEquipSlot; // Re-fetch to ensure we have the latest state, especially ItemDataInstance
+        int32 TempSlotIndex = -1; // Temporary for re-fetch
+        if (!FindItemSlot(ItemIDFromInventory, ActualItemToEquipSlot, TempSlotIndex) || TempSlotIndex != ItemSlotIndex)
+        {
+             UE_LOG(LogMJ12DevPlugin, Error, TEXT("EquipItemFromInventory: Item %s disappeared from original slot %d during data load. Aborting."), *ItemIDFromInventory.ToString(), ItemSlotIndex);
+             return;
+        }
+        // Crucially, ensure the ItemDataInstance used for CanEquipItem is the one just loaded.
+        ActualItemToEquipSlot.ItemDataInstance = LoadedItemData;
+
+
+        if (!CanEquipItem(ActualItemToEquipSlot.ItemDataInstance, TargetEquipSlotTag))
+        {
+            // CanEquipItem logs the reason
+            return;
+        }
+
+        // If slot is already occupied, unequip old item first
+        if (EquippedItems.Contains(TargetEquipSlotTag))
+        {
+            FName OldItemID = EquippedItems[TargetEquipSlotTag].ItemID;
+            // Temporarily store the item being unequipped to avoid issues if it's the same item ID being swapped
+            FInventorySlot UnequippedItemDetails = EquippedItems[TargetEquipSlotTag];
+
+            if (!UnequipItem(TargetEquipSlotTag)) // Unequip first
+            {
+                UE_LOG(LogMJ12DevPlugin, Warning, TEXT("EquipItemFromInventory: Failed to unequip previous item from slot %s."), *TargetEquipSlotTag.ToString());
+                // If UnequipItem failed to add back to inventory, and we add it back now, ensure it does not interfere with the item being equipped.
+                // This part of logic can get complex if inventory space is an issue. AddItem has its own checks.
+                return; // Failed to unequip, cannot proceed
+            }
+            UE_LOG(LogMJ12DevPlugin, Log, TEXT("EquipItemFromInventory: Unequipped %s to make space for %s in slot %s."), *OldItemID.ToString(), *ItemIDFromInventory.ToString(), *TargetEquipSlotTag.ToString());
+        }
+
+        // Create the equipped item slot (typically quantity 1 for equipment)
+        FInventorySlot EquippedSlot(ItemIDFromInventory, 1);
+        EquippedSlot.ItemDataInstance = ActualItemToEquipSlot.ItemDataInstance; // Use the loaded ItemData
+
+        // Remove one instance from inventory BEFORE adding to equipped map
+        // to handle cases where inventory is full and unequip->additem fails.
+        if (!RemoveItem(ItemIDFromInventory, 1)) // Use base RemoveItem
+        {
+            UE_LOG(LogMJ12DevPlugin, Error, TEXT("EquipItemFromInventory: Failed to remove item %s from inventory for equip! Aborting equip."), *ItemIDFromInventory.ToString());
+            // If the item we just unequipped needs to be restored to the slot, this logic would be more complex.
+            // For now, assume failure to remove from inventory means we cannot proceed with equipping.
+            // Consider if the previously unequipped item needs to be re-equipped or if its AddItem in UnequipItem was successful.
+            return;
+        }
+
+        EquippedItems.Add(TargetEquipSlotTag, EquippedSlot);
+        UE_LOG(LogMJ12DevPlugin, Log, TEXT("EquipItemFromInventory: Item %s equipped to slot %s."), *ItemIDFromInventory.ToString(), *TargetEquipSlotTag.ToString());
+
+        if (GetNetMode() == NM_ListenServer || GetNetMode() == NM_DedicatedServer || GetNetMode() == NM_Standalone)
+        {
+            OnEquipmentSlotChanged.Broadcast(TargetEquipSlotTag, &EquippedItems[TargetEquipSlotTag]);
+        }
+    };
+
+    // If ItemData is already loaded in the slot from inventory, use it directly.
+    if (ItemToEquipSlotRecord.ItemDataInstance && ItemToEquipSlotRecord.ItemDataInstance->AreAssetsLoaded())
+    {
+        UE_LOG(LogMJ12DevPlugin, Log, TEXT("EquipItemFromInventory: ItemData for %s already loaded. Proceeding synchronously."), *ItemIDFromInventory.ToString());
+        PerformEquipLogic(ItemToEquipSlotRecord.ItemDataInstance);
+    }
+    else // ItemData not loaded or assets not ready, request load.
+    {
+        UE_LOG(LogMJ12DevPlugin, Log, TEXT("EquipItemFromInventory: ItemData for %s not loaded or assets pending. Requesting async load."), *ItemIDFromInventory.ToString());
+        // Pass the ItemSlotIndex to ensure we can update the correct FInventorySlot's ItemDataInstance
+        // The lambda passed to RequestLoadItemData in UInventoryComponent already handles setting ItemDataInstance for a given slot index.
+        // We need to ensure that the 'ItemToEquipSlotRecord' gets its ItemDataInstance updated if it's a copy,
+        // or that PerformEquipLogic uses the correctly updated instance from the main Inventory array.
+        // The RequestLoadItemData in InventoryComponent updates the FInventorySlot in its Inventory TArray.
+        // So, PerformEquipLogic should ideally re-fetch the FInventorySlot or be passed the ItemData directly.
+        // The ItemSlotIndex is captured by PerformEquipLogic to potentially re-verify.
+
+        RequestLoadItemData(ItemIDFromInventory, [this, PerformEquipLogic, ItemSlotIndex, ItemIDFromInventory](UItemData* LoadedData) {
+            // After data is loaded (or load failed) by the base RequestLoadItemData:
+            if (LoadedData)
+            {
+                 // If the item still exists in the original inventory slot, ensure its ItemDataInstance is updated.
+                 // This is a bit redundant if RequestLoadItemData's callback (HandleItemDataLoaded) already did this,
+                 // but double-checking doesn't hurt, or rely on FindItemSlot inside PerformEquipLogic.
+                if (Inventory.IsValidIndex(ItemSlotIndex) && Inventory[ItemSlotIndex].ItemID == ItemIDFromInventory)
+                {
+                    Inventory[ItemSlotIndex].ItemDataInstance = LoadedData;
+                }
+            }
+            // Now call the core equip logic with the loaded data (which might be null if load failed)
+            PerformEquipLogic(LoadedData);
+        });
+    }
+
+    return true; // Indicates the equip process has been initiated. Actual success is asynchronous.
+}
+
+bool UEquipmentComponent::EquipItemByCreatingInstance(FGameplayTag TargetEquipSlotTag, FName ItemIDToCreateAndEquip)
+{
+    if (GetOwnerRole() < ROLE_Authority)
+    {
+        UE_LOG(LogMJ12DevPlugin, Warning, TEXT("EquipItemByCreatingInstance called on Client. Denied."));
+        return false;
+    }
+
+    if (TargetEquipSlotTag == FGameplayTag::EmptyTag || ItemIDToCreateAndEquip == NAME_None) return false;
+
+    RequestLoadItemData(ItemIDToCreateAndEquip, [this, TargetEquipSlotTag, ItemIDToCreateAndEquip](UItemData* LoadedItemData){
+        if (!LoadedItemData)
+        {
+            UE_LOG(LogMJ12DevPlugin, Warning, TEXT("EquipItemByCreatingInstance: Could not load ItemData for %s."), *ItemIDToCreateAndEquip.ToString());
+            return;
+        }
+
+        if (!CanEquipItem(LoadedItemData, TargetEquipSlotTag))
+        {
+            return;
+        }
+
+        if (EquippedItems.Contains(TargetEquipSlotTag))
+        {
+            if (!UnequipItem(TargetEquipSlotTag))
+            {
+                UE_LOG(LogMJ12DevPlugin, Warning, TEXT("EquipItemByCreatingInstance: Failed to unequip previous item from slot %s."), *TargetEquipSlotTag.ToString());
+                return;
+            }
+        }
+
+        FInventorySlot NewEquippedSlot(ItemIDToCreateAndEquip, 1);
+        NewEquippedSlot.ItemDataInstance = LoadedItemData;
+        EquippedItems.Add(TargetEquipSlotTag, NewEquippedSlot);
+
+        UE_LOG(LogMJ12DevPlugin, Log, TEXT("EquipItemByCreatingInstance: Item %s created and equipped to slot %s."), *ItemIDToCreateAndEquip.ToString(), *TargetEquipSlotTag.ToString());
+
+        if (GetNetMode() == NM_ListenServer || GetNetMode() == NM_DedicatedServer || GetNetMode() == NM_Standalone)
+        {
+            OnEquipmentSlotChanged.Broadcast(TargetEquipSlotTag, &EquippedItems[TargetEquipSlotTag]);
+        }
+    });
+
+    return true; 
+}
+
+
+bool UEquipmentComponent::UnequipItem(FGameplayTag EquipSlotTag)
+{
+    if (GetOwnerRole() < ROLE_Authority)
+    {
+        UE_LOG(LogMJ12DevPlugin, Warning, TEXT("UnequipItem called on Client. Denied."));
+        return false; 
+    }
+
+    if (!EquippedItems.Contains(EquipSlotTag))
+    {
+        UE_LOG(LogMJ12DevPlugin, Warning, TEXT("UnequipItem: No item in slot %s."), *EquipSlotTag.ToString());
+        return false;
+    }
+
+    FInventorySlot UnequippedSlot = EquippedItems[EquipSlotTag];
+    EquippedItems.Remove(EquipSlotTag);
+
+    if (!AddItem(UnequippedSlot.ItemID, UnequippedSlot.Quantity)) 
+    {
+        UE_LOG(LogMJ12DevPlugin, Error, TEXT("UnequipItem: Failed to add item %s back to inventory! Item may be lost if not handled."), *UnequippedSlot.ItemID.ToString());
+    }
+
+    UE_LOG(LogMJ12DevPlugin, Log, TEXT("UnequipItem: Item %s unequipped from slot %s and returned to inventory."), *UnequippedSlot.ItemID.ToString(), *EquipSlotTag.ToString());
+
+    if (GetNetMode() == NM_ListenServer || GetNetMode() == NM_DedicatedServer || GetNetMode() == NM_Standalone)
+    {
+        OnEquipmentSlotChanged.Broadcast(EquipSlotTag, nullptr);
+    }
+
+    return true;
+}
+
+bool UEquipmentComponent::GetEquippedItem(FGameplayTag EquipSlotTag, FInventorySlot& OutEquippedItem) const
+{
+    if (EquippedItems.Contains(EquipSlotTag))
+    {
+        OutEquippedItem = EquippedItems[EquipSlotTag];
+        return true;
+    }
+    return false;
+}

--- a/MJ12DevPlugin/Source/MJ12DevPluginModule/Private/MJ12DevPluginModule.cpp
+++ b/MJ12DevPlugin/Source/MJ12DevPluginModule/Private/MJ12DevPluginModule.cpp
@@ -1,0 +1,22 @@
+#include "MJ12DevPluginModule.h"
+
+DEFINE_LOG_CATEGORY(LogMJ12DevPlugin);
+
+#define LOCTEXT_NAMESPACE "FMJ12DevPluginModule"
+
+void FMJ12DevPluginModule::StartupModule()
+{
+    // This code will execute after your module is loaded into memory; the exact timing is specified in the .uplugin file per-module
+    UE_LOG(LogMJ12DevPlugin, Warning, TEXT("MJ12DevPluginModule has started!"));
+}
+
+void FMJ12DevPluginModule::ShutdownModule()
+{
+    // This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,
+    // we call this function before unloading the module.
+    UE_LOG(LogMJ12DevPlugin, Warning, TEXT("MJ12DevPluginModule has shut down!"));
+}
+
+#undef LOCTEXT_NAMESPACE
+
+IMPLEMENT_MODULE(FMJ12DevPluginModule, MJ12DevPluginModule)

--- a/MJ12DevPlugin/Source/MJ12DevPluginModule/Public/EquipmentComponent.h
+++ b/MJ12DevPlugin/Source/MJ12DevPluginModule/Public/EquipmentComponent.h
@@ -1,0 +1,59 @@
+// EquipmentComponent.h
+#pragma once
+
+#include "CoreMinimal.h"
+#include "InventoryComponent.h" // Inherits from UInventoryComponent
+#include "GameplayTagContainer.h"  // For FGameplayTag
+#include "EquipmentComponent.generated.h"
+
+// Delegate broadcast when an equipment slot changes (item equipped/unequipped and data loaded).
+// Provides the slot tag and the FInventorySlot (or nullptr if unequipped).
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnEquipmentSlotChanged, FGameplayTag, SlotTag, const FInventorySlot*, SlotData);
+
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class MJ12DEVPLUGINMODULE_API UEquipmentComponent : public UInventoryComponent // Changed API macro
+{
+    GENERATED_BODY()
+
+public:
+    UEquipmentComponent();
+
+    UPROPERTY(BlueprintAssignable, Category="Equipment")
+    FOnEquipmentSlotChanged OnEquipmentSlotChanged;
+
+    // Using FGameplayTag for EquipSlot key for flexibility and data-driven slot definitions
+    UPROPERTY(ReplicatedUsing=OnRep_EquippedItems, BlueprintReadOnly, Category="Equipment")
+    TMap<FGameplayTag, FInventorySlot> EquippedItems;
+
+    UFUNCTION(BlueprintCallable, Category="Equipment")
+    bool EquipItemFromInventory(FGameplayTag TargetEquipSlotTag, FName ItemIDFromInventory);
+
+    UFUNCTION(BlueprintCallable, Category="Equipment")
+    bool EquipItemByCreatingInstance(FGameplayTag TargetEquipSlotTag, FName ItemIDToCreateAndEquip);
+
+    UFUNCTION(BlueprintCallable, Category="Equipment")
+    bool UnequipItem(FGameplayTag EquipSlotTag);
+
+    UFUNCTION(BlueprintPure, Category="Equipment")
+    bool GetEquippedItem(FGameplayTag EquipSlotTag, FInventorySlot& OutEquippedItem) const;
+
+    //~ Begin Server RPCs
+    UFUNCTION(Server, Reliable, WithValidation, BlueprintCallable, Category="MJ12|Equipment")
+    void ServerEquipItemFromInventory(FGameplayTag TargetEquipSlotTag, FName ItemIDFromInventory);
+
+    UFUNCTION(Server, Reliable, WithValidation, BlueprintCallable, Category="MJ12|Equipment")
+    void ServerEquipItemByCreatingInstance(FGameplayTag TargetEquipSlotTag, FName ItemIDToCreateAndEquip);
+
+    UFUNCTION(Server, Reliable, WithValidation, BlueprintCallable, Category="MJ12|Equipment")
+    void ServerUnequipItem(FGameplayTag EquipSlotTag);
+    //~ End Server RPCs
+
+protected:
+    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+
+    UFUNCTION()
+    void OnRep_EquippedItems();
+
+private:
+    bool CanEquipItem(const UItemData* ItemDataToEquip, FGameplayTag TargetEquipSlotTag) const;
+};

--- a/MJ12DevPlugin/Source/MJ12DevPluginModule/Public/InventoryComponent.h
+++ b/MJ12DevPlugin/Source/MJ12DevPluginModule/Public/InventoryComponent.h
@@ -1,0 +1,110 @@
+// InventoryComponent.h
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "ItemTableRow.h" // For FItemTableRow (though primarily used in .cpp)
+#include "ItemData.h"     // For UItemData
+#include "InventoryComponent.generated.h"
+
+// Forward declaration for FStreamableHandle
+struct FStreamableHandle;
+
+USTRUCT(BlueprintType)
+struct FInventorySlot
+{
+    GENERATED_BODY()
+
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category="Inventory Slot") // ItemID is set internally
+    FName ItemID;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Inventory Slot", meta=(ClampMin="0")) // Quantity can be modified
+    int32 Quantity;
+
+    UPROPERTY(BlueprintReadOnly, Category="Inventory Slot", Transient) // ItemData is runtime, not saved, reloaded from ItemID
+    UItemData* ItemDataInstance;
+
+    // Default constructor
+    FInventorySlot() : ItemID(NAME_None), Quantity(0), ItemDataInstance(nullptr) {}
+    FInventorySlot(FName InItemID, int32 InQuantity) : ItemID(InItemID), Quantity(InQuantity), ItemDataInstance(nullptr) {}
+
+    bool operator==(const FName& InItemID) const
+    {
+        return ItemID == InItemID;
+    }
+};
+
+// Delegate broadcast when a specific slot's data (especially UItemData) has been updated.
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnInventorySlotUpdated, const FInventorySlot&, UpdatedSlot);
+// Delegate broadcast when the entire inventory has undergone a significant change (e.g., after initial replication and data loading).
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnInventoryReloaded);
+
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class MJ12DEVPLUGINMODULE_API UInventoryComponent : public UActorComponent // Changed API macro
+{
+    GENERATED_BODY()
+
+public:
+    UInventoryComponent();
+
+    UPROPERTY(BlueprintAssignable, Category="Inventory")
+    FOnInventorySlotUpdated OnInventorySlotUpdated;
+
+    UPROPERTY(BlueprintAssignable, Category="Inventory")
+    FOnInventoryReloaded OnInventoryReloaded;
+
+    UPROPERTY(ReplicatedUsing=OnRep_Inventory, BlueprintReadOnly, Category="Inventory")
+    TArray<FInventorySlot> Inventory;
+
+    UFUNCTION(BlueprintCallable, Category="Inventory")
+    bool AddItem(FName ItemID, int32 Quantity = 1);
+
+    UFUNCTION(BlueprintCallable, Category="Inventory")
+    bool RemoveItem(FName ItemID, int32 Quantity = 1);
+
+    UFUNCTION(BlueprintCallable, Category="Inventory")
+    bool RemoveItemAt(int32 SlotIndex, int32 Quantity = 1);
+
+    UFUNCTION(BlueprintPure, Category="Inventory")
+    int32 GetItemQuantity(FName ItemID) const;
+
+    UFUNCTION(BlueprintPure, Category="Inventory")
+    bool FindItemSlot(FName ItemID, FInventorySlot& OutSlot, int32& OutSlotIndex) const;
+
+    UFUNCTION(BlueprintPure, Category="Inventory")
+    UItemData* GetItemData(FName ItemID) const;
+
+    //~ Begin Server RPCs
+    UFUNCTION(Server, Reliable, WithValidation, BlueprintCallable, Category="MJ12|Inventory")
+    void ServerAddItem(FName ItemID, int32 Quantity);
+
+    UFUNCTION(Server, Reliable, WithValidation, BlueprintCallable, Category="MJ12|Inventory")
+    void ServerRemoveItem(FName ItemID, int32 Quantity);
+
+    UFUNCTION(Server, Reliable, WithValidation, BlueprintCallable, Category="MJ12|Inventory")
+    void ServerRemoveItemAt(int32 SlotIndex, int32 Quantity);
+    //~ End Server RPCs
+
+protected:
+    virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+    virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+
+    UFUNCTION()
+    virtual void OnRep_Inventory();
+
+    // Central function to load item data from DataTable and handle async asset loading
+    // Callback is invoked once ItemData is created and its core assets (meshes, icon) are loaded or confirmed valid.
+    void RequestLoadItemData(FName ItemID, TFunction<void(UItemData* LoadedData)> Callback);
+
+    UPROPERTY(EditDefaultsOnly, Category="Inventory", meta=(RequiredAssetDataTags="RowStructure=ItemTableRow"))
+    UDataTable* ItemDataTable;
+
+private:
+    // Manages active async load requests for ItemData assets
+    TMap<FName, TSharedPtr<FStreamableHandle>> ActiveLoadHandles;
+
+    // Counter for pending OnRep loads to fire OnInventoryReloaded once
+    int32 PendingOnRepLoads = 0;
+    void HandleItemDataLoaded(FName ItemID, UItemData* LoadedData, int32 SlotIndex = -1, bool bFromOnRep = false);
+};

--- a/MJ12DevPlugin/Source/MJ12DevPluginModule/Public/ItemData.h
+++ b/MJ12DevPlugin/Source/MJ12DevPluginModule/Public/ItemData.h
@@ -1,0 +1,46 @@
+// ItemData.h
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/NoExportTypes.h"
+#include "GameplayTagContainer.h" // Required for GameplayTags
+#include "ItemData.generated.h"
+
+UCLASS(BlueprintType)
+class MJ12DEVPLUGINMODULE_API UItemData : public UObject // Changed API macro
+{
+    GENERATED_BODY()
+
+public:
+    UPROPERTY(BlueprintReadOnly, Category="Item Data")
+    FName ItemID;
+
+    UPROPERTY(BlueprintReadOnly, Category="Item Data")
+    FText DisplayName;
+
+    // Soft pointers allow these to be loaded on demand
+    UPROPERTY(BlueprintReadOnly, Category="Item Data")
+    TSoftObjectPtr<UStaticMesh> StaticMesh;
+
+    UPROPERTY(BlueprintReadOnly, Category="Item Data")
+    TSoftObjectPtr<USkeletalMesh> SkeletalMesh;
+
+    UPROPERTY(BlueprintReadOnly, Category="Item Data")
+    TSoftObjectPtr<UTexture2D> Icon;
+
+    UPROPERTY(BlueprintReadOnly, Category="Item Data")
+    int32 MaxStackSize;
+
+    UPROPERTY(BlueprintReadOnly, Category="Item Data")
+    float Weight;
+
+    UPROPERTY(BlueprintReadOnly, Category="Item Data")
+    FGameplayTagContainer ItemTags;
+
+    UPROPERTY(BlueprintReadOnly, Category="Item Data")
+    FGameplayTag EquipTargetSlotTag;
+
+    // Helper function to check if assets are loaded
+    UFUNCTION(BlueprintPure, Category="Item Data")
+    bool AreAssetsLoaded() const;
+};

--- a/MJ12DevPlugin/Source/MJ12DevPluginModule/Public/ItemTableRow.h
+++ b/MJ12DevPlugin/Source/MJ12DevPluginModule/Public/ItemTableRow.h
@@ -1,0 +1,40 @@
+// ItemTableRow.h
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataTable.h"
+#include "GameplayTagContainer.h" // Required for GameplayTags
+#include "ItemTableRow.generated.h"
+
+USTRUCT(BlueprintType)
+struct FItemTableRow : public FTableRowBase
+{
+    GENERATED_BODY()
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Item Properties")
+    FName ItemID; // Should be unique across all items
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Item Properties")
+    FText DisplayName;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Item Properties")
+    TSoftObjectPtr<UStaticMesh> StaticMesh;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Item Properties")
+    TSoftObjectPtr<USkeletalMesh> SkeletalMesh;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Item Properties")
+    TSoftObjectPtr<UTexture2D> Icon;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Item Properties", meta=(ClampMin="1"))
+    int32 MaxStackSize = 1;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Item Properties")
+    float Weight = 0.0f;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Item Properties")
+    FGameplayTagContainer ItemTags; // Tags for various item properties (e.g., "Item.Consumable", "Item.Weapon", "Item.Equippable")
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Item Properties", meta=(EditCondition="ItemTags.HasTag(FGameplayTag::RequestGameplayTag(FName(\"Item.Equippable\")))", EditConditionHides))
+    FGameplayTag EquipTargetSlotTag; // Defines the equipment slot this item fits into (e.g., "Equipment.Slot.Weapon", "Equipment.Slot.Head")
+};

--- a/MJ12DevPlugin/Source/MJ12DevPluginModule/Public/MJ12DevPluginModule.h
+++ b/MJ12DevPlugin/Source/MJ12DevPluginModule/Public/MJ12DevPluginModule.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Modules/ModuleManager.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogMJ12DevPlugin, Log, All);
+
+class FMJ12DevPluginModule : public IModuleInterface
+{
+public:
+
+    /** IModuleInterface implementation */
+    virtual void StartupModule() override;
+    virtual void ShutdownModule() override;
+};

--- a/README.md
+++ b/README.md
@@ -114,3 +114,64 @@ Embark on a metaphysical odyssey through time, space, and psyche.
 ## Helpful Documentation
 
 - TBD
+
+---
+
+## MJ12DevPlugin
+
+This plugin, `MJ12DevPlugin`, is a foundational C++ framework designed to house common development tools, utilities, and custom gameplay systems for the *Majestik: 12 Realms* project.
+
+### Purpose
+
+*   **Centralization:** Provides a central location for custom C++ code, keeping it modular and separate from the main game project or other marketplace assets.
+*   **Rapid Development:** Enables faster iteration on new gameplay mechanics, editor tools, and utility functions.
+*   **Maintainability:** Simplifies updates and management of shared code components.
+
+### Structure
+
+The plugin is organized as follows:
+
+*   `MJ12DevPlugin/` (Root directory)
+    *   `MJ12DevPlugin.uplugin`: The plugin descriptor file.
+    *   `Source/`: Contains the plugin's source code.
+        *   `MJ12DevPluginModule/`: The primary module for the plugin.
+            *   `Public/`: Public header files. Includes `MJ12DevPluginModule.h` (main module interface), `ItemTableRow.h`, `ItemData.h`, `InventoryComponent.h`, and `EquipmentComponent.h`.
+            *   `Private/`: Private implementation files. Includes `MJ12DevPluginModule.cpp` and `MJ12DevPluginComponents.cpp` (containing implementations for inventory/equipment).
+            *   `MJ12DevPluginModule.Build.cs`: The build script for the module.
+    *   `Content/`: For any plugin-specific assets (currently empty).
+
+### Getting Started with the Plugin
+
+1.  **Ensure the plugin is in the project's `Plugins` directory.** If it's not already there (e.g., if cloned separately), copy the `MJ12DevPlugin` folder into your project's `Plugins` folder. Create a `Plugins` folder at the root of your Unreal project if it doesn't exist.
+2.  **Enable the Plugin:** Open your Unreal Engine project, go to `Edit -> Plugins`, search for "MJ12 Development Plugin" (or "MJ12"), and ensure it's enabled. Restart the editor if prompted.
+3.  **Compile:** The plugin code will be compiled automatically when you build your project. If you add new C++ classes to the plugin, you'll need to compile from your IDE (Visual Studio, Rider, etc.) or trigger a build from the Unreal Editor.
+
+### Adding New Functionality
+
+*   **New C++ Classes:** Add new `.h` files to `Source/MJ12DevPluginModule/Public/` and corresponding `.cpp` files to `Source/MJ12DevPluginModule/Private/`.
+*   **Editor Modules/Tools:** For editor-specific functionality, you might add a new module of type "Editor" within the `Source` directory and update the `.uplugin` file accordingly.
+*   **Content:** Add any plugin-specific Blueprints, materials, etc., to the `MJ12DevPlugin/Content/` directory.
+
+This plugin serves as a starting point and is being expanded with core gameplay systems and specific tools.
+
+#### Core Gameplay Systems
+
+The `MJ12DevPlugin` now includes a foundational Inventory and Equipment system:
+
+*   **Item Management:**
+    *   Items are defined in DataTables using the `FItemTableRow` struct (`Source/MJ12DevPluginModule/Public/ItemTableRow.h`).
+    *   Runtime item instances are represented by `UItemData` objects (`Source/MJ12DevPluginModule/Public/ItemData.h`), which support asynchronous loading of associated assets (meshes, icons).
+*   **Inventory Component (`UInventoryComponent`):**
+    *   Located in `Source/MJ12DevPluginModule/Public/InventoryComponent.h`.
+    *   Manages a collection of items (`FInventorySlot`).
+    *   Supports replication for multiplayer.
+    *   Provides delegates (`OnInventorySlotUpdated`, `OnInventoryReloaded`) for UI and game logic to respond to changes.
+    *   Handles asynchronous loading of item data when items are added or replicated.
+*   **Equipment Component (`UEquipmentComponent`):**
+    *   Located in `Source/MJ12DevPluginModule/Public/EquipmentComponent.h`.
+    *   Manages equipped items, using `FGameplayTag` to define equipment slots (e.g., "Equipment.Slot.Weapon").
+    *   Inherits from `UInventoryComponent`, potentially allowing shared inventory space or logic.
+    *   Supports replication and provides a delegate (`OnEquipmentSlotChanged`) for updates.
+    *   Handles asynchronous data loading for equipping items, including a refactored `EquipItemFromInventory` method to correctly manage data dependencies.
+
+These systems provide a robust base for handling items and character equipment within the game.


### PR DESCRIPTION
I've implemented several recommendations to enhance the MJ12DevPlugin for robustness, networking, and Blueprint usability.

Changes include:
- Updated MJ12DevPluginModule.Build.cs:
    - PublicDependencies: Core, CoreUObject, Engine
    - PrivateDependencies: GameplayTags
    - Removed Slate and SlateCore.
- UEquipmentComponent:
    - The constructor now calls SetIsReplicatedByDefault(true).
    - I've added Server RPC declarations for EquipItemFromInventory, EquipItemByCreatingInstance, and UnequipItem to EquipmentComponent.h (implementations are pending in .cpp).
- UInventoryComponent:
    - I've added Server RPC declarations and implementations for ServerAddItem, ServerRemoveItem, and ServerRemoveItemAt.
- Removed manual OnRep_... calls:
    - I've removed direct server-side calls to OnRep_Inventory() and OnRep_EquippedItems() in their respective components.
    - I've ensured local delegates (OnInventorySlotUpdated, OnEquipmentSlotChanged) are broadcast for server/standalone contexts where these OnRep calls were previously made.

Work remaining in this enhancement pass:
- Add implementations for UEquipmentComponent Server RPCs in .cpp.
- Update UCLASS macros for Blueprintable, ClassGroup=(MJ12), and ensure BlueprintCallable/Assignable for relevant functions/delegates.
- Final review of authority checks and include paths.